### PR TITLE
added greater than or equal to check

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,6 @@
   ],
   "depends": {
     "fabricloader": ">=0.10.8",
-    "minecraft": "1.16.4"
+    "minecraft": ">=1.16.4"
   }
 }


### PR DESCRIPTION
your mod was saying it required 1.16.4 in-game after downloading it from curse. this change in the fabric mod JSON allows it to accept any version higher